### PR TITLE
Promotion profile page implemented

### DIFF
--- a/api/promotionApi.js
+++ b/api/promotionApi.js
@@ -64,6 +64,18 @@ const getAllPromotions = () => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
+const getAPromotionAndItsShows = (id) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/promotions/profile/${id}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  })
+    .then((resp) => resolve(resp.json()))
+    .catch(reject);
+});
+
 export {
-  createPromotion, updatePromotion, getPromotion, getAllPromotions,
+  createPromotion, updatePromotion, getPromotion, getAllPromotions, getAPromotionAndItsShows,
 };

--- a/components/Cards/PromotionCard.js
+++ b/components/Cards/PromotionCard.js
@@ -4,11 +4,11 @@ import Link from 'next/link';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-function PromotionCard({ promotionName, logoUrl, id }) {
+function PromotionCard({ promotionName, logo, id }) {
   return (
-    <Link href={`/promotions/${id}`}>
+    <Link href={`/promotions/profile/${id}`}>
       <a>
-        <img src={logoUrl} alt="Promotion Logo" width={350} height={200} />
+        <img src={logo} alt="Promotion Logo" width={350} height={200} />
         <div className="promotion-card-name"><h4>{promotionName}</h4></div>
       </a>
     </Link>
@@ -17,7 +17,7 @@ function PromotionCard({ promotionName, logoUrl, id }) {
 
 PromotionCard.propTypes = {
   promotionName: PropTypes.string.isRequired,
-  logoUrl: PropTypes.string.isRequired,
+  logo: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired,
 };
 

--- a/components/Cards/ShowCard.js
+++ b/components/Cards/ShowCard.js
@@ -1,0 +1,27 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable @next/next/no-img-element */
+import Link from 'next/link';
+import PropTypes from 'prop-types';
+
+export default function ShowCard({ show }) {
+  return (
+    <Link href={`/shows/show-page/${show.id}`}>
+      <a>
+        <img src={show.showImage} alt="Promotion Logo" width={350} height={200} />
+        <div className="promotion-card-name"><h4>{show.showName}</h4></div>
+      </a>
+    </Link>
+  );
+}
+
+ShowCard.propTypes = {
+  show: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    showName: PropTypes.string.isRequired,
+    showType: PropTypes.string.isRequired,
+    showTime: PropTypes.string.isRequired,
+    showDay: PropTypes.string.isRequired,
+    showDescription: PropTypes.string.isRequired,
+    showImage: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/components/Forms/PromotionForm.js
+++ b/components/Forms/PromotionForm.js
@@ -21,7 +21,7 @@ import { updatePromotion, createPromotion } from '../../api/promotionApi';
 const initialState = {
   promotionName: '',
   acronym: '',
-  logoUrl: '',
+  logo: '',
   hq: '',
   established: '',
   owner: '',
@@ -76,7 +76,7 @@ export default function PromotionForm({ promotionObj }) {
       reader.onloadend = () => {
         setFormData((prevData) => ({
           ...prevData,
-          logoUrl: reader.result,
+          logo: reader.result,
         }));
       };
       reader.readAsDataURL(file);
@@ -85,7 +85,7 @@ export default function PromotionForm({ promotionObj }) {
 
   return (
     <div>
-      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <Button variant="contained" color="primary" onClick={handleClickOpen}>
         {promotionObj ? 'Edit Promotion' : 'Create Promotion'}
       </Button>
       <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
@@ -150,12 +150,12 @@ export default function PromotionForm({ promotionObj }) {
                   <FormGroup>
                     <FormLabel> <Typography component="div" variant="h7" color="textPrimary">Logo</Typography></FormLabel>
                     <Form.Control type="file" accept="image/*" onChange={handleFileUpload} />
-                    {formData.logoUrl && (
+                    {formData.logo && (
                     <div style={{
                       marginTop: '10px', marginLeft: '60px', width: '400px', height: '400px', position: 'relative',
                     }}
                     >
-                      <Image key={formData.logoUrl} src={formData.logoUrl} alt="Logo" layout="fill" objectFit="cover" />
+                      <Image key={formData.logo} src={formData.logo} alt="Logo" layout="fill" objectFit="cover" />
                     </div>
                     )}
                   </FormGroup>
@@ -185,7 +185,7 @@ PromotionForm.propTypes = {
     id: PropTypes.number,
     promotionName: PropTypes.string,
     acronym: PropTypes.string,
-    logoUrl: PropTypes.string,
+    logo: PropTypes.string,
     hq: PropTypes.string,
     established: PropTypes.number,
     owner: PropTypes.string,

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Button, Stack } from '@mui/material';
 import { useAuth } from '../utils/context/authContext';
 import PromotionForm from '../components/Forms/PromotionForm';
 import { getPromotion } from '../api/promotionApi';
@@ -26,8 +27,13 @@ function Home() {
       }}
     >
       <h1>Hello {user.fbUser.displayName}! </h1>
+      <br />
       <div id="landing-page-buttons">
-        <PromotionForm promotionObj={promotion} />
+        <Stack spacing={3}>
+          <PromotionForm promotionObj={promotion} />
+          <Button variant="contained" size="medium">Create Performer</Button>
+          <Button variant="contained" size="medium">Shows</Button>
+        </Stack>
       </div>
     </div>
   );

--- a/pages/promotions/all.js
+++ b/pages/promotions/all.js
@@ -23,7 +23,7 @@ const AllPromotionsPage = () => {
       <h2>All Promotions</h2>
       <div className="card-container">
         {promotions.map((promotion) => (
-          <PromotionCard key={promotion.id} id={promotion.id} promotion={promotion} promotionName={promotion.promotionName} logoUrl={promotion.logoUrl} />
+          <PromotionCard key={promotion.id} id={promotion.id} promotion={promotion} promotionName={promotion.promotionName} logo={promotion.logo} />
         ))}
       </div>
     </>

--- a/pages/promotions/profile/[id].js
+++ b/pages/promotions/profile/[id].js
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+  Card, CardContent, CardMedia, Stack, Typography,
+} from '@mui/material';
+import { getAPromotionAndItsShows } from '../../../api/promotionApi';
+import ShowCard from '../../../components/Cards/ShowCard';
+
+export default function PromotionPage() {
+  const [promotion, setPromotion] = useState();
+  const router = useRouter();
+  const { id } = router.query;
+
+  useEffect(() => {
+    getAPromotionAndItsShows(id).then(setPromotion);
+  }, [promotion]);
+
+  return (
+    <>
+      <Card style={{ maxWidth: '100%', maxHeight: '21rem' }} className="promotionInfo">
+        <div style={{ display: 'flex' }}>
+          <CardMedia
+            style={{
+              flex: '1 0 33%', maxHeight: '21rem', maxWidth: '50%', objectFit: 'contain',
+            }}
+            component="img"
+            image={promotion?.logo}
+            alt="Promotion Logo"
+          />
+          <CardContent style={{ flex: '1 0 50%', objectFit: 'contain' }}>
+            <Stack spacing={2}>
+              <Typography variant="h5" component="div">
+                {promotion?.promotionName} ({promotion?.acronym})
+              </Typography>
+              <Typography variant="body1" component="div">
+                Based out of {promotion?.hq}
+              </Typography>
+              <Typography variant="body1" component="div">
+                Est. in {promotion?.established}
+              </Typography>
+              <Typography variant="body1" component="div">
+                Owned By: {promotion?.owner}
+              </Typography>
+              <Typography variant="body1" component="div">
+                Show Frequency: {promotion?.showFrequency}
+              </Typography>
+              <Typography variant="body1" component="div">
+                {promotion?.description}
+              </Typography>
+            </Stack>
+          </CardContent>
+        </div>
+      </Card>
+      <div className="show-cards-container">
+        {promotion?.shows?.map((show) => <ShowCard key={show.id} show={show} />)}
+      </div>
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,3 +59,21 @@ body {
   text-align: center;
   margin-bottom: 7%;
 }
+
+.promotionInfo {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
+  text-align: center;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin: 10px;
+}
+
+.show-cards-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  align-items: center;
+}


### PR DESCRIPTION
Clicking a promotion in the Promotions page now brings the user to the promotion's profile page, which has their logo and promotion information in a card at the top and a flex box of cards beneath showing a show logo and the show name that will link to a show page when I complete it.